### PR TITLE
Basic API stuff now populates the first HomeFragment View

### DIFF
--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponseAttributeCraft.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponseAttributeCraft.java
@@ -1,0 +1,9 @@
+package com.yarnify.API.ResponseModels;
+
+public class ResponseAttributeCraft {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePattern.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePattern.java
@@ -1,6 +1,5 @@
 package com.yarnify.API.ResponseModels;
 
-import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -8,15 +7,16 @@ public class ResponsePattern {
 
 
     //need to dynamically get this field from query?
-    @SerializedName("1335913")
+    @SerializedName(value = "1335913", alternate = {"1337254"})
     @Expose(deserialize = true)
-    private JsonObject pattern;
+    private ResponsePatternAttributes pattern;
 
-    public JsonObject getPattern() {
+    public ResponsePatternAttributes getPatternAttributes() {
+
         return pattern;
     }
 
-    public void setPattern(JsonObject pattern) {
+    public void setPattern(ResponsePatternAttributes pattern) {
         this.pattern = pattern;
     }
 }

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributes.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributes.java
@@ -1,0 +1,29 @@
+package com.yarnify.API.ResponseModels;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+
+public class ResponsePatternAttributes {
+
+    @SerializedName("name")
+    private String title;
+    private String id;
+    private String updated;
+    private String image;
+    private ResponseAttributeCraft craft;
+    private ResponsePatternAuthor pattern_author;
+    private ArrayList<ResponsePatternAttributesPhotos> photos;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public ResponsePatternAuthor getPattern_author() {
+        return pattern_author;
+    }
+
+    public ResponseAttributeCraft getCraft() {
+        return craft;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributesPhotos.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributesPhotos.java
@@ -1,0 +1,11 @@
+package com.yarnify.API.ResponseModels;
+
+import java.util.ArrayList;
+
+public class ResponsePatternAttributesPhotos {
+    private ArrayList<ResponsePatternAttributesPhotosPhoto> photos;
+
+    public ArrayList<ResponsePatternAttributesPhotosPhoto> getPhotos() {
+        return photos;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributesPhotosPhoto.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAttributesPhotosPhoto.java
@@ -1,0 +1,9 @@
+package com.yarnify.API.ResponseModels;
+
+public class ResponsePatternAttributesPhotosPhoto {
+    private String medium_url;
+
+    public String getMedium_url() {
+        return medium_url;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAuthor.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternAuthor.java
@@ -1,0 +1,9 @@
+package com.yarnify.API.ResponseModels;
+
+public class ResponsePatternAuthor {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternNeedleSize.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternNeedleSize.java
@@ -1,0 +1,13 @@
+package com.yarnify.API.ResponseModels;
+
+public class ResponsePatternNeedleSize{
+    public int id;
+    public String us;
+    public double metric;
+    public Object us_steel;
+    public boolean crochet;
+    public boolean knitting;
+    public Object hook;
+    public String name;
+    public String pretty_metric;
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternNeedleSizeList.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/ResponsePatternNeedleSizeList.java
@@ -1,0 +1,7 @@
+package com.yarnify.API.ResponseModels;
+
+import java.util.ArrayList;
+
+public class ResponsePatternNeedleSizeList {
+    private ArrayList<ResponsePatternNeedleSize> pattern_needle_sizes;
+}

--- a/app/src/main/java/com/yarnify/API/ResponseModels/TypeAdapters/PhotosAdapter.java
+++ b/app/src/main/java/com/yarnify/API/ResponseModels/TypeAdapters/PhotosAdapter.java
@@ -1,0 +1,44 @@
+package com.yarnify.API.ResponseModels.TypeAdapters;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.yarnify.API.ResponseModels.ResponsePatternAttributesPhotos;
+
+import java.io.IOException;
+
+
+
+//Unnecessary but good practice. This is the form that needs to happen for deserializing
+// dynamic pattern ids
+
+
+public class PhotosAdapter extends TypeAdapter<ResponsePatternAttributesPhotos> {
+    @Override
+    public void write(JsonWriter out, ResponsePatternAttributesPhotos value) throws IOException {
+
+    }
+
+    @Override
+    public ResponsePatternAttributesPhotos read(JsonReader in) throws IOException {
+        ResponsePatternAttributesPhotos photos = new ResponsePatternAttributesPhotos();
+        in.beginObject();
+        String fieldname = null;
+
+        while (in.hasNext()) {
+
+            JsonToken token = in.peek();
+
+            if(token.equals(JsonToken.NAME)){
+                fieldname = in.nextName();
+            }
+
+            if ("name".equals(fieldname)){
+                token = in.peek();
+
+            }
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/com/yarnify/API/ResponseUtilities/ToPojo.java
+++ b/app/src/main/java/com/yarnify/API/ResponseUtilities/ToPojo.java
@@ -8,15 +8,13 @@ import com.yarnify.API.ResponseModels.ResponsePatternList;
 
 public class ToPojo {
 
-    public ToPojo(){
-
-    }
+    public ToPojo(){}
     public ResponsePatternList fromJSONSimple(String json){
 
         JsonObject jsonObject = new JsonParser().parse(json).getAsJsonObject();
 
         Gson gson = new GsonBuilder()
-                .excludeFieldsWithoutExposeAnnotation()
+                //.excludeFieldsWithoutExposeAnnotation()
                 .create();
 
         ResponsePatternList alexPatternClassFromJSON = gson.fromJson(jsonObject, ResponsePatternList.class);

--- a/app/src/main/java/com/yarnify/MainActivity.java
+++ b/app/src/main/java/com/yarnify/MainActivity.java
@@ -2,22 +2,17 @@ package com.yarnify;
 
 import android.os.Bundle;
 
-import com.example.yarnify.R;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
-
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.yarnify.R;
 import com.example.yarnify.databinding.ActivityMainBinding;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.yarnify.API.Request;
 import com.yarnify.viewmodel.PatternViewModel;
-
-import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -38,6 +33,9 @@ public class MainActivity extends AppCompatActivity {
         //this can be used to nuke the pattern table
         //patternViewModel = new ViewModelProvider(this).get(PatternViewModel.class);
         //patternViewModel.deleteAllPatterns();
+
+        Request request =
+                new Request("patterns.json?ids=1335913");
     }
 
     public void setUpBottomNav() {

--- a/app/src/main/java/com/yarnify/ui/home/HomeFragment.java
+++ b/app/src/main/java/com/yarnify/ui/home/HomeFragment.java
@@ -1,19 +1,22 @@
 package com.yarnify.ui.home;
 
 import android.os.Bundle;
+import android.os.StrictMode;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.yarnify.R;
-import com.yarnify.cardAdapter;
 import com.example.yarnify.databinding.FragmentHomeBinding;
+import com.yarnify.API.Request;
+import com.yarnify.API.ResponseModels.ResponsePatternList;
+import com.yarnify.API.ResponseUtilities.ToPojo;
+import com.yarnify.cardAdapter;
 import com.yarnify.model.Pattern;
 import com.yarnify.viewmodel.PatternViewModel;
 
@@ -30,6 +33,31 @@ public class HomeFragment extends Fragment {
 
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
+
+        // Alex Changes start here
+
+        // I don't think this is an ideal way to allow Network stuff on the main thread
+        // Just using it for testing purposes
+        StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
+        StrictMode.setThreadPolicy(policy);
+
+        Request request =
+                new Request("patterns.json?ids=1335913");
+
+
+        ToPojo toPojo =
+                new ToPojo();
+
+        ResponsePatternList ac = toPojo.fromJSONSimple(request.getResponse());
+
+
+        // I can make cleaner methods for these, but this is an example of how the classes
+        // are deserialize and accessed
+        String title1 = ac.getPatterns().getPatternAttributes().getTitle();
+        String name1 = ac.getPatterns().getPatternAttributes().getPattern_author().getName();
+        String craft1 = ac.getPatterns().getPatternAttributes().getCraft().getName();
+
+
         // Inflate the layout for this fragment using the FragmentHomeBinding
         binding = FragmentHomeBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
@@ -37,7 +65,12 @@ public class HomeFragment extends Fragment {
         //clear the exampleList before adding new pattern objects
         exampleList.clear();
         //hardcoded example pattern objects
-        exampleList.add(new Pattern(R.drawable.ravelry_sample_photo, "gloves", "Susan", "Crochet", "https://www.ravelry.com/patterns/library/helia-bolero", 1500));
+        exampleList.add(new Pattern(R.drawable.ravelry_sample_photo, title1, name1, craft1, "https://www.ravelry.com/patterns/library/helia-bolero", 1500));
+
+
+        // Alex changes end here
+
+
         exampleList.add(new Pattern(R.drawable.armillafirm_small2, "thin sweater", "Jack", "Crochet", "https://www.ravelry.com/patterns/library/helia-bolero", 1500));
         exampleList.add(new Pattern(R.drawable.beanies_medium2, "beanies", "Bob", "Crochet", "https://www.ravelry.com/patterns/library/helia-bolero", 1500));
 

--- a/app/src/test/java/com/yarnify/API/RequestTest.java
+++ b/app/src/test/java/com/yarnify/API/RequestTest.java
@@ -21,7 +21,7 @@ public class RequestTest {
     @Test
     public void getResponseToPojoTest() {
         Request request =
-                new Request("patterns.json?ids=1335913");
+                new Request("patterns.json?ids=" + "1335913");
 
         ToPojo toPojo =
                 new ToPojo();
@@ -29,12 +29,12 @@ public class RequestTest {
         ResponsePatternList ac = toPojo.fromJSONSimple(request.getResponse());
 
 
-        assertNotNull(ac.getPatterns().getPattern());
+        assertNotNull(ac.getPatterns().getPatternAttributes());
 
         //Shows that ToPojo is deserializing into ResponsePatternList and ResponsePattern correctly
         //Next steps would be to
         //      How to get and set serialized name of pattern...
         //      create more accurate classes and work through them
-        assertEquals("test", ac.getPatterns().getPattern().get("gauge"));
+        assertEquals("test", ac.getPatterns().getPatternAttributes().getTitle());
     }
 }


### PR DESCRIPTION
 Added a couple basic calls in the Home fragment with comments as an example of how the API stuff will work.

*Note - I set these within the Home fragment onCreateView method. It's a temporary workaround to ignore thread issues, as you can't normally run network services on the main thread.

        StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
        StrictMode.setThreadPolicy(policy);