### PR TITLE
Hiding Credentials

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,15 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        // Hiding the API Key. Use local.properties to place API_KEY=$insertApiKeyHere$
+        // Make sure local.properties is in git.ignore
+        /*  It loads from the rootProject file "local properties" to get the API Key so it can be used
+        in the buildConfigField and eventually globally. */
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file("local.properties").newDataInputStream())
+
+        buildConfigField "String", "API_KEY", "\"${properties.getProperty("API_KEY")}\""
     }
 
     buildTypes {

--- a/app/src/main/java/com/yarnify/API/Request.java
+++ b/app/src/main/java/com/yarnify/API/Request.java
@@ -1,7 +1,12 @@
 
 package com.yarnify.API;
 import static android.content.ContentValues.TAG;
+import static com.example.yarnify.BuildConfig.API_KEY;
+
 import android.util.Log;
+
+import com.example.yarnify.BuildConfig;
+
 import java.io.IOException;
 import okhttp3.OkHttpClient;
 
@@ -26,6 +31,7 @@ public class Request {
         this.response = requestResponse(url);
     }
 
+
     private String requestResponse(String url){
         String responseString = "";
 
@@ -34,7 +40,7 @@ public class Request {
         okhttp3.Request request = new okhttp3.Request.Builder()
                 .url("https://api.ravelry.com/" + url)
                 .method("GET", null)
-                .addHeader("Authorization", "Basic cmVhZC1lZTgzYjdmMWNlMmE0ZjQ1YWFmOGQxYTkwNzUwMGM2ZDpWWUFRc0M4VTYyN1ZUNUl1UHY5eS9ZdVFEVWJIUVpTL1h0aXFJNVRi")
+                .addHeader("Authorization", API_KEY)
                 .build();
         try {
             okhttp3.Response response = client.newCall(request).execute();


### PR DESCRIPTION
Removed the hardcoded API credentials using a buildConfigField in build.gradle(app). From this point forward, please implement your own or use our shared API_KEY by adding it into your local.properties file.